### PR TITLE
change mockstore to record calls to UpsertId

### DIFF
--- a/datastore/mockstore/mockstore.go
+++ b/datastore/mockstore/mockstore.go
@@ -52,6 +52,7 @@ func (c mockCollection) Upsert(selector interface{}, update interface{}) (*mgo.C
 }
 
 func (c mockCollection) UpsertId(selector interface{}, update interface{}) (*mgo.ChangeInfo, error) {
+	c.Called(selector, update)
 	return nil, nil
 }
 


### PR DESCRIPTION
This is needed so that we can assert that this method has been called
with the expected args in tests.