### PR TITLE
Adds a Use method for switching logical databases

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -38,6 +38,7 @@ type Config struct {
 // Session is an interface for a MongoDB session
 type Session interface {
 	DB() (Database, func())
+	Use(name string) Session
 }
 
 // Database is an interface for accessing a MongoDB database
@@ -91,6 +92,12 @@ func (s *mgoSession) DB() (Database, func()) {
 	copy := s.Session.Copy()
 	closer := func() { copy.Close() }
 	return &mgoDatabase{copy.DB(s.conf.Database)}, closer
+}
+
+// Change the database in use
+func (s *mgoSession) Use(name string) Session {
+	s.conf.Database = name
+	return s
 }
 
 // mgoDatabase wraps an mgo.Database and implements Database

--- a/datastore/mockstore/mockstore.go
+++ b/datastore/mockstore/mockstore.go
@@ -16,6 +16,10 @@ func (s mockSession) DB() (datastore.Database, func()) {
 	return mockDatabase{s.Mock}, func() {}
 }
 
+func (s mockSession) Use(name string) datastore.Session {
+	return s
+}
+
 // mockDatabase acts as a mock datastore.Database
 type mockDatabase struct {
 	*mock.Mock


### PR DESCRIPTION
We need this to switch between databases within the same session. The mgo implementation of Session supports `DB(name string)`, but our interface simplified this by setting the name of the database automatically when calling `DB()` based on what the session was originally configured with. So far, we've only needed to use a single database, but to use multiple databases we need the ability to switch.