### PR TITLE
Expose DropCollection, EnsureIndex and Fsync

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -59,6 +59,8 @@ type Collection interface {
 	UpdateId(id, update interface{}) error
 	Upsert(selector, update interface{}) (*mgo.ChangeInfo, error)
 	UpsertId(id, update interface{}) (*mgo.ChangeInfo, error)
+	DropCollection() error
+	EnsureIndex(index mgo.Index) error
 }
 
 // Bulk is an interface for running Bulk queries on a MongoDB collection

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -39,6 +39,7 @@ type Config struct {
 type Session interface {
 	DB() (Database, func())
 	Use(name string) Session
+	Fsync(async bool) error
 }
 
 // Database is an interface for accessing a MongoDB database

--- a/datastore/mockstore/mockstore.go
+++ b/datastore/mockstore/mockstore.go
@@ -85,6 +85,14 @@ func (c mockCollection) Pipe(pipeline interface{}) datastore.Pipe {
 	return mockPipe{c.Mock}
 }
 
+func (c mockCollection) DropCollection() error {
+	return nil
+}
+
+func (c mockCollection) EnsureIndex(index mgo.Index) error {
+	return nil
+}
+
 // mockBulk acts as a mock datastore.Bulk
 type mockBulk struct {
 	*mock.Mock

--- a/datastore/mockstore/mockstore.go
+++ b/datastore/mockstore/mockstore.go
@@ -20,6 +20,10 @@ func (s mockSession) Use(name string) datastore.Session {
 	return s
 }
 
+func (s mockSession) Fsync(async bool) error {
+	return nil
+}
+
 // mockDatabase acts as a mock datastore.Database
 type mockDatabase struct {
 	*mock.Mock


### PR DESCRIPTION
Exposes `DropCollection`, `EnsureIndex` and `Fsync` so that we can invalidate the cache when using MongoDB as the backend.

Ref https://github.com/kubeapps/kubeapps/issues/1521