### PR TITLE
Ensure mockstore's Upsert registers the call.

### DIFF
--- a/datastore/mockstore/mockstore.go
+++ b/datastore/mockstore/mockstore.go
@@ -56,6 +56,7 @@ func (c mockCollection) Insert(docs ...interface{}) error {
 }
 
 func (c mockCollection) Upsert(selector interface{}, update interface{}) (*mgo.ChangeInfo, error) {
+	c.Called(selector, update)
 	return nil, nil
 }
 


### PR DESCRIPTION
The reason tests of the mocked store started failing when I switched from `UpsertId` to `Upsert`.

Ref #1521. Needed for #1551